### PR TITLE
Update for aws.s3 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,7 @@ RUN \
         RSQLite \
         odbc \
         keyring \
-    && installGithub.r \
-        cloudyr/aws.s3@ee5b4a37027b21673f3d6af3a934e69ade5476d0
+        aws.s3
     
     
 VOLUME ["/home"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,14 @@ RUN \
 
 RUN \
     
-    R -e " \
-        update.packages(ask ='no'); \
-        install.packages(c('RPostgreSQL', 'RSQLite', 'odbc', 'keyring')); \
-        remotes::install_github('cloudyr/aws.s3@ee5b4a37027b21673f3d6af3a934e69ade5476d0') ; \
-    " \
+    R -e "update.packages(ask = 'no')" \
+    && install2.r --error \
+        RPostgreSQL \
+        RSQLite \
+        odbc \
+        keyring \
+    && installGithub.r \
+        cloudyr/aws.s3@ee5b4a37027b21673f3d6af3a934e69ade5476d0
     
     
 VOLUME ["/home"]


### PR DESCRIPTION
The [aws.s3](https://cran.r-project.org/package=aws.s3) package is back on CRAN: this PR updates the dockerfile.

I've also modified the command used to install packages in order to use [littler](https://cran.r-project.org/package=littler) scripts [which are available in all rocker images](https://github.com/rocker-org/rocker-versioned/blob/c3e8cc52d6652fe7c4dfcf5f83e9f90dbaf52dc6/r-ver/latest.Dockerfile#L122-L124).  
IMO, this will ease track changes.