### PR TITLE
Ajout libarchive-dev pour installer le package archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN \
 	alien \
         libsodium-dev \
         libsecret-1-dev \
+        libarchive-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
 


### PR DESCRIPTION
Pour pouvoir installer le package R archive qui permet de dézipper des archives 7z par exemple (utile pour les fonds de cartes IGN par exemple) : https://github.com/jimhester/archive.