### PR TITLE
Add dependencies for reproducible publications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ ENV HADOOP_OPTIONAL_TOOLS "hadoop-aws"
 ENV PATH="${JAVA_HOME}/bin:${SPARK_HOME}/bin:${HADOOP_HOME}/bin:${PATH}"
 
 ENV \
-
     # Change the locale
     LANG=fr_FR.UTF-8 
 
@@ -38,7 +37,6 @@ RUN \
     # Add Shiny support
     export ADD=shiny \
     && bash /etc/cont-init.d/add \
-    
     # Install system librairies
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils software-properties-common \
@@ -64,7 +62,6 @@ RUN \
     && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ \
     && sudo apt update -y \
     && apt install -y adoptopenjdk-8-hotspot \
-
     # Handle localization
     && cp /usr/share/zoneinfo/Europe/Paris /etc/localtime \
     && sed -i -e 's/# fr_FR.UTF-8 UTF-8/fr_FR.UTF-8 UTF-8/' /etc/locale.gen \
@@ -73,7 +70,6 @@ RUN \
 
 
 RUN \
-    
     R -e "update.packages(ask = 'no')" \
     && install2.r --error \
         RPostgreSQL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,13 @@ RUN \
         libsodium-dev \
         libsecret-1-dev \
         libarchive-dev \
-        libglpk-dev \        
+        libglpk-dev \
+        chromium \
+        ghostscript \
+        fontconfig \
+        fonts-symbola \
+        fonts-noto \
+        fonts-freefont-ttf \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
@@ -81,7 +87,11 @@ RUN \
         paws \
         SparkR \
         vaultr \
-    && R -e "remotes::install_github('inseeFrLab/doremifasol')"
+    # install the latest version of pagedown using a CRAN mirror instead of the MRAN snapshot
+    && install2.r --error --repos https://cran.rstudio.com pagedown \
+    && installGithub.r \
+        inseeFrLab/doremifasol \
+        spyrales/gouvdown
     
     
 VOLUME ["/home"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,9 @@ RUN \
         gnupg2 \
         unixodbc \
         unixodbc-dev \
-	odbc-postgresql \
-	libsqliteodbc \
-	alien \
+        odbc-postgresql \
+        libsqliteodbc \
+        alien \
         libsodium-dev \
         libsecret-1-dev \
         libarchive-dev \
@@ -78,9 +78,9 @@ RUN \
         keyring \
         aws.s3 \
         Rglpk \
-	paws \
+        paws \
         SparkR \
-	vaultr \
+        vaultr \
     && R -e "remotes::install_github('inseeFrLab/doremifasol')"
     
     


### PR DESCRIPTION
This PR adds:

- pagedown and required system dependencies (Chromium and Ghostscript)
- https://github.com/spyrales/gouvdown for the French governmental publications 